### PR TITLE
calling ReattachToExecutor now requires cpustats.Compute to be passed

### DIFF
--- a/hello/driver.go
+++ b/hello/driver.go
@@ -452,7 +452,7 @@ func (d *HelloDriverPlugin) RecoverTask(handle *drivers.TaskHandle) error {
 		return fmt.Errorf("failed to build ReattachConfig from taskConfig state: %v", err)
 	}
 
-	execImpl, pluginClient, err := executor.ReattachToExecutor(plugRC, d.logger)
+	execImpl, pluginClient, err := executor.ReattachToExecutor(plugRC, d.logger, d.nomadConfig.Topology.Compute())
 	if err != nil {
 		return fmt.Errorf("failed to reattach to executor: %v", err)
 	}


### PR DESCRIPTION
This should fix issue https://github.com/hashicorp/nomad-skeleton-driver-plugin/issues/39